### PR TITLE
Feature/send perfdata

### DIFF
--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -222,7 +222,7 @@ int npcdmod_handle_data(int event_type, void *data) {
                         hoststate[hostchkdata->state],
                         hostchkdata->output,
                         hostchkdata->long_output,
-                        hostschkdata->perf_data,
+                        hostchkdata->perf_data,
                         (int)hostchkdata->timestamp.tv_sec);
 
                 if (written >= PERFDATA_BUFFER) {

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -215,12 +215,14 @@ int npcdmod_handle_data(int event_type, void *data) {
                     "\"state\":\"%s\","     // HOSTSTATE
                     "\"summary\":\"%s\","   // HOSTOUTPUT
                     "\"details\":\"%s\","   // HOSTlongoutput
+                    "\"perfdata\":\"%s\","   // HOSTperfdata
                     "\"time\":\"%d\""       // TIMET
                     "}",
                         hostchkdata->host_name,
                         hoststate[hostchkdata->state],
                         hostchkdata->output,
                         hostchkdata->long_output,
+                        hostschkdata->perf_data,
                         (int)hostchkdata->timestamp.tv_sec);
 
                 if (written >= PERFDATA_BUFFER) {
@@ -264,6 +266,7 @@ int npcdmod_handle_data(int event_type, void *data) {
                     //"\"time\":\"%f\","      // HOSTLATENCY
                     "\"summary\":\"%s\","   // HOSTOUTPUT
                     "\"details\":\"%s\","   // HOSTlongoutput
+                    "\"perfdata\":\"%s\","   // SERVICEperfdata
                     "\"time\":\"%d\""       // TIMET
                     "}",
                         srvchkdata->host_name,
@@ -273,6 +276,7 @@ int npcdmod_handle_data(int event_type, void *data) {
                         //srvchkdata->latency,
                         srvchkdata->output,
                         srvchkdata->long_output,
+                        srvchkdata->perf_data,
                         (int)srvchkdata->timestamp.tv_sec);
 
                 if (written >= PERFDATA_BUFFER) {


### PR DESCRIPTION
This pull request gives flapjackfeeder the ability to send perfdata for host and service checks through to the redis event queue for flapjack.
