### PR TITLE
Support _tag _initial_failure_delay and _repeat_failure_delay custom vars

### DIFF
--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -220,6 +220,13 @@ int npcdmod_handle_data(int event_type, void *data) {
 
             host = find_host(hostchkdata->host_name);
 
+            snprintf(temp_buffer, sizeof(temp_buffer) - 1,
+                "flapjackfeeder: 1st customvar: %s first_notification_delay: %f\n",
+                host->custom_variables->variable_name,
+                host->first_notification_delay);
+            temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
+            write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
+
             if (hostchkdata->type == NEBTYPE_HOSTCHECK_PROCESSED) {
 
                 int written = generate_event(push_buffer, PERFDATA_BUFFER,

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -91,7 +91,7 @@ int nebmodule_init(int flags, char *args, nebmodule *handle) {
     /* set some info - this is completely optional, as Nagios doesn't do anything with this data */
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_TITLE, "flapjackfeeder");
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_AUTHOR, "Birger Schmidt");
-    neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_TITLE, "Copyright (c) 2013-2015 Birger Schmidt");
+    neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_COPYRIGHT, "Copyright (c) 2013-2015 Birger Schmidt");
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_VERSION, "0.0.4");
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_LICENSE, "GPL v2");
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_DESC, "A simple performance data / check result extractor / pipe writer.");

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -23,7 +23,7 @@
 
 #ifdef HAVE_NAEMON_H
 /* we compile for the naemon core ( -DHAVE_NAEMON_H was given as compile option ) */
-include "../naemon/naemon.h"
+#include "../naemon/naemon.h"
 #include "string.h"
 #else
 /* we compile for the legacy nagios 3 / icinga 1 core */

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -77,7 +77,6 @@ char *expand_escapes(const char* src);
 
 int generate_event(char *buffer, size_t buffer_size, char *host_name, char *service_name,
                    char *state, char *output, char *long_output, char *tags,
-//                   double first_notification_delay, 
                    long initial_failure_delay, long repeat_failure_delay, 
                    int event_time);
 

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -1,7 +1,7 @@
 /*****************************************************************************
  *
  * FLAPJACKFEEDER.C
- * Copyright (c) 2013 Birger Schmidt (http://flapjack.io)
+ * Copyright (c) 2013-2015 Birger Schmidt (http://flapjack.io)
  *
  * Derived from NPCDMOD.C ...
  * Copyright (c) 2008-2010 PNP4Nagios Project (http://www.pnp4nagios.org)
@@ -92,13 +92,13 @@ int nebmodule_init(int flags, char *args, nebmodule *handle) {
     /* set some info - this is completely optional, as Nagios doesn't do anything with this data */
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_TITLE, "flapjackfeeder");
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_AUTHOR, "Birger Schmidt");
-    neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_TITLE, "Copyright (c) 2013 Birger Schmidt");
-    neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_VERSION, "0.0.3");
+    neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_TITLE, "Copyright (c) 2013-2015 Birger Schmidt");
+    neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_VERSION, "0.0.4");
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_LICENSE, "GPL v2");
     neb_set_module_info(npcdmod_module_handle, NEBMODULE_MODINFO_DESC, "A simple performance data / check result extractor / pipe writer.");
 
     /* log module info to the Nagios log file */
-    write_to_all_logs("flapjackfeeder: Copyright (c) 2013 Birger Schmidt, derived from npcdmod", NSLOG_INFO_MESSAGE);
+    write_to_all_logs("flapjackfeeder: Copyright (c) 2013-2015 Birger Schmidt, derived from npcdmod", NSLOG_INFO_MESSAGE);
 
     /* process arguments */
     if (npcdmod_process_module_args(args) == ERROR) {

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -549,7 +549,6 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
     char *escaped_state        = expand_escapes(state);
     char *escaped_output       = expand_escapes(output);
     char *escaped_long_output  = expand_escapes(long_output);
-    char *escaped_tags         = expand_escapes(tags);
 
     int written = snprintf(buffer, buffer_size,
                             "{"
@@ -569,7 +568,7 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
                                 escaped_state,
                                 escaped_output,
                                 escaped_long_output,
-                                escaped_tags,
+                                tags,
                                 initial_failure_delay,
                                 repeat_failure_delay,
                                 event_time);
@@ -579,7 +578,6 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
     free(escaped_state);
     free(escaped_output);
     free(escaped_long_output);
-    free(escaped_tags);
 
     return(written);
 }

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -549,6 +549,7 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
     char *escaped_state        = expand_escapes(state);
     char *escaped_output       = expand_escapes(output);
     char *escaped_long_output  = expand_escapes(long_output);
+    char *escaped_tags         = expand_escapes(tags);
 
     int written = snprintf(buffer, buffer_size,
                             "{"
@@ -568,7 +569,7 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
                                 escaped_state,
                                 escaped_output,
                                 escaped_long_output,
-                                tags,
+                                escaped_tags,
                                 initial_failure_delay,
                                 repeat_failure_delay,
                                 event_time);
@@ -578,6 +579,7 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
     free(escaped_state);
     free(escaped_output);
     free(escaped_long_output);
+    free(escaped_tags);
 
     return(written);
 }

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -228,7 +228,7 @@ int npcdmod_handle_data(int event_type, void *data) {
             char *cur = temp_buffer, * const end = temp_buffer + sizeof temp_buffer;
             temp_buffer[0] = '\x0';
             while (currentcustomvar != NULL) {
-                if (strcmp(currentcustomvar->variable_name, "TAGS") == 0) {
+                if (strcmp(currentcustomvar->variable_name, "TAG") == 0) {
                   cur += snprintf(cur, end - cur,
                       "\"%s\",",
                       currentcustomvar->variable_value
@@ -240,8 +240,6 @@ int npcdmod_handle_data(int event_type, void *data) {
                 else if (strcmp(currentcustomvar->variable_name, "REPEAT_FAILURE_DELAY") == 0) {
                       repeat_failure_delay = strtol(currentcustomvar->variable_value,NULL,10);
                 }
-                // I think this is not needed, as snprintf takes care of the tailing 0
-                //temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
                 currentcustomvar = currentcustomvar->next;
             }
             cur--;
@@ -263,7 +261,6 @@ int npcdmod_handle_data(int event_type, void *data) {
                     hostchkdata->output,
                     hostchkdata->long_output,
                     temp_buffer,
-//                    (double)host->first_notification_delay,
                     initial_failure_delay,
                     repeat_failure_delay,
                     (int)hostchkdata->timestamp.tv_sec);
@@ -287,9 +284,6 @@ int npcdmod_handle_data(int event_type, void *data) {
                     write_to_all_logs("flapjackfeeder: lost check result due to redis connection fail.", NSLOG_INFO_MESSAGE);
                 }
             }
-            // I fear I've implemented a memory leak, but the following produces a segfault :-(
-            //free (initial_failure_delay);
-            //free (repeat_failure_delay);
         }
         break;
 
@@ -308,7 +302,7 @@ int npcdmod_handle_data(int event_type, void *data) {
                 char *cur = temp_buffer, * const end = temp_buffer + sizeof temp_buffer;
                 temp_buffer[0] = '\x0';
                 while (currentcustomvar != NULL) {
-                    if (strcmp(currentcustomvar->variable_name, "TAGS") == 0) {
+                    if (strcmp(currentcustomvar->variable_name, "TAG") == 0) {
                       cur += snprintf(cur, end - cur,
                           "\"%s\",",
                           currentcustomvar->variable_value
@@ -320,8 +314,6 @@ int npcdmod_handle_data(int event_type, void *data) {
                     else if (strcmp(currentcustomvar->variable_name, "REPEAT_FAILURE_DELAY") == 0) {
                           repeat_failure_delay = strtol(currentcustomvar->variable_value,NULL,10);
                     }
-                    // I think this is not needed, as snprintf takes care of the tailing 0
-                    //temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
                     currentcustomvar = currentcustomvar->next;
                 }
                 cur--;
@@ -341,7 +333,6 @@ int npcdmod_handle_data(int event_type, void *data) {
                     srvchkdata->output,
                     srvchkdata->long_output,
                     temp_buffer,
-//                    (double)service->first_notification_delay,
                     initial_failure_delay,
                     repeat_failure_delay,
                     (int)srvchkdata->timestamp.tv_sec);
@@ -364,9 +355,6 @@ int npcdmod_handle_data(int event_type, void *data) {
                 } else {
                     write_to_all_logs("flapjackfeeder: lost check result due to redis connection fail.", NSLOG_INFO_MESSAGE);
                 }
-                // I fear I've implemented a memory leak, but the following produces a segfault :-(
-                //free (initial_failure_delay);
-                //free (repeat_failure_delay);
             }
         }
         break;
@@ -554,7 +542,6 @@ char *expand_escapes(const char* src)
 
 int generate_event(char *buffer, size_t buffer_size, char *host_name, char *service_name,
                    char *state, char *output, char *long_output, char *tags,
-//                   double first_notification_delay, 
                    long initial_failure_delay, long repeat_failure_delay, 
                    int event_time) {
 
@@ -563,7 +550,6 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
     char *escaped_state        = expand_escapes(state);
     char *escaped_output       = expand_escapes(output);
     char *escaped_long_output  = expand_escapes(long_output);
-    char *escaped_tags         = expand_escapes(tags);
 
     int written = snprintf(buffer, buffer_size,
                             "{"
@@ -574,10 +560,8 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
                                 "\"summary\":\"%s\","                  // HOSTOUTPUT
                                 "\"details\":\"%s\","                  // HOSTlongoutput
                                 "\"tags\":[%s],"                       // tags
-                                "\"tags_debug\":[%s],"                       // tags
-//                                "\"first_notification_delay\":\"%f\"," // first_notification_delay
-                                "\"initial_failure_delay\":%lu,"        // initial_failure_delay
-                                "\"repeat_failure_delay\":%lu,"         // repeat_failure_delay
+                                "\"initial_failure_delay\":%lu,"       // initial_failure_delay
+                                "\"repeat_failure_delay\":%lu,"        // repeat_failure_delay
                                 "\"time\":%d"                          // TIMET
                             "}",
                                 escaped_host_name,
@@ -586,8 +570,6 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
                                 escaped_output,
                                 escaped_long_output,
                                 tags,
-                                tags,
-//                                first_notification_delay,
                                 initial_failure_delay,
                                 repeat_failure_delay,
                                 event_time);
@@ -597,7 +579,6 @@ int generate_event(char *buffer, size_t buffer_size, char *host_name, char *serv
     free(escaped_state);
     free(escaped_output);
     free(escaped_long_output);
-    free(escaped_tags);
 
     return(written);
 }


### PR DESCRIPTION
Add support for custom vars.

Multiple lines of 
`_tag`s
as well as
`_initial_failure_delay` and `_repeat_failure_delay`.