### PR TITLE
support multiple redis targets

### DIFF
--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -121,6 +121,7 @@ int nebmodule_init(int flags, char *args, nebmodule *handle) {
     
         /* open redis connection to push check results */
         currentredistarget->rediscontext = redisConnectWithTimeout(currentredistarget->redis_host, atoi(currentredistarget->redis_port), timeout);
+        currentredistarget->redis_connection_established = 0;
         if (currentredistarget->rediscontext == NULL || currentredistarget->rediscontext->err) {
             if (currentredistarget->rediscontext) {
                 snprintf(temp_buffer, sizeof(temp_buffer) - 1,
@@ -184,7 +185,7 @@ void npcdmod_file_roller() {
     redistarget *currentredistarget = redistargets;
     while (currentredistarget != NULL) {
         /* open redis connection to push check results if needed */
-        if (currentredistarget->rediscontext == NULL || currentredistarget->rediscontext->err) {
+        if (currentredistarget->rediscontext == NULL || currentredistarget->rediscontext->err || currentredistarget->redis_connection_established == 0) {
             snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: redis connection has to be (re)established (redis host '%s', redis port '%s').", 
                 currentredistarget->redis_host, currentredistarget->redis_port);
             temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
@@ -207,6 +208,14 @@ void npcdmod_file_roller() {
                 write_to_all_logs("flapjackfeeder: redis connection established.", NSLOG_INFO_MESSAGE);
             }
         }
+        /*
+        else {
+            snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: redis connection seems to be fine (redis host '%s', redis port '%s' redis-> '%d').", 
+                currentredistarget->redis_host, currentredistarget->redis_port, currentredistarget->rediscontext->err);
+            temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
+            write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
+        }
+        */
         currentredistarget = currentredistarget->next;
     }
 

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -491,6 +491,7 @@ int npcdmod_process_config_var(char *arg) {
             }
             new_redistarget->redis_host = NULL;
             new_redistarget->redis_port = NULL;
+            new_redistarget->rediscontext = NULL;
             new_redistarget->redis_connection_established = 0;
         }
         if (redistargets != NULL && redistargets->redis_host == NULL) {
@@ -516,6 +517,7 @@ int npcdmod_process_config_var(char *arg) {
             }
             new_redistarget->redis_host = NULL;
             new_redistarget->redis_port = NULL;
+            new_redistarget->rediscontext = NULL;
             new_redistarget->redis_connection_established = 0;
         }
         if (redistargets != NULL && redistargets->redis_port == NULL) {

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -534,6 +534,11 @@ int npcdmod_process_config_var(char *arg) {
     else if (!strcmp(var, "redis_connect_retry_interval"))
         redis_connect_retry_interval = strdup(val);
 
+    else if (!strcmp(var, "timeout")) {
+        timeout.tv_sec = atoi(val);
+        timeout.tv_usec = 0;
+    }
+
     else {
         snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: I don't know what to do with '%s' as argument.", var);
         temp_buffer[sizeof(temp_buffer) - 1] = '\x0';

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -300,15 +300,20 @@ int npcdmod_handle_data(int event_type, void *data) {
                         if (reply != NULL) {
                             freeReplyObject(reply);
                         } else {
-                            snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: unable to write to redis, connection lost (redis host '%s', redis port '%s').", 
-                                currentredistarget->redis_host, currentredistarget->redis_port);
+                            snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: redis write (%s:%s) fail, lost check result (host %s - %s).", 
+                                currentredistarget->redis_host, currentredistarget->redis_port,
+                                hostchkdata->host_name, hoststate[hostchkdata->state]);
                             temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
                             write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
                             currentredistarget->redis_connection_established = 0;
                             redisFree(currentredistarget->rediscontext);
                         }
                     } else {
-                        write_to_all_logs("flapjackfeeder: lost check result due to redis connection fail.", NSLOG_INFO_MESSAGE);
+                        snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: redis connection (%s:%s) fail, lost check result (host %s - %s).", 
+                            currentredistarget->redis_host, currentredistarget->redis_port,
+                            hostchkdata->host_name, hoststate[hostchkdata->state]);
+                        temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
+                        write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
                     }
                     currentredistarget = currentredistarget->next;
                 }
@@ -379,15 +384,20 @@ int npcdmod_handle_data(int event_type, void *data) {
                         if (reply != NULL) {
                             freeReplyObject(reply);
                         } else {
-                            snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: unable to write to redis, connection lost (redis host '%s', redis port '%s').", 
-                                currentredistarget->redis_host, currentredistarget->redis_port);
+                            snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: redis write (%s:%s) fail, lost check result (%s : %s - %s).", 
+                                currentredistarget->redis_host, currentredistarget->redis_port,
+                                srvchkdata->host_name, srvchkdata->service_description, servicestate[srvchkdata->state]);
                             temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
                             write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
                             currentredistarget->redis_connection_established = 0;
                             redisFree(currentredistarget->rediscontext);
                         }
                     } else {
-                        write_to_all_logs("flapjackfeeder: lost check result due to redis connection fail.", NSLOG_INFO_MESSAGE);
+                        snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: redis connection (%s:%s) fail, lost check result (%s : %s - %s).", 
+                            currentredistarget->redis_host, currentredistarget->redis_port,
+                            srvchkdata->host_name, srvchkdata->service_description, servicestate[srvchkdata->state]);
+                        temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
+                        write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
                     }
                     currentredistarget = currentredistarget->next;
                 }

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -179,8 +179,8 @@ void redis_re_connect() {
         }
         /*
         else {
-            snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: redis connection seems to be fine (redis host '%s', redis port '%s' redis-> '%d').", 
-                currentredistarget->redis_host, currentredistarget->redis_port, currentredistarget->rediscontext->err);
+            snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: redis connection (%s:%s) seems to be fine.", 
+                currentredistarget->redis_host, currentredistarget->redis_port);
             temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
             write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
         }
@@ -486,7 +486,6 @@ int npcdmod_process_config_var(char *arg) {
         if (redistargets == NULL || redistargets->redis_host != NULL) {
             /* allocate memory for a new redis target */
             if ((new_redistarget = malloc(sizeof(redistarget))) == NULL) {
-                //logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for redis target\n");
                 write_to_all_logs("Error: Could not allocate memory for redis target\n", NSLOG_INFO_MESSAGE);
             }
             new_redistarget->redis_host = NULL;
@@ -533,12 +532,19 @@ int npcdmod_process_config_var(char *arg) {
         }
     }
 
-    else if (!strcmp(var, "redis_connect_retry_interval"))
+    else if (!strcmp(var, "redis_connect_retry_interval")) {
         redis_connect_retry_interval = strdup(val);
+        snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: configure %ss as retry interval for redis reconnects.", redis_connect_retry_interval);
+        temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
+        write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
+    }
 
     else if (!strcmp(var, "timeout")) {
         timeout.tv_sec = atoi(val);
         timeout.tv_usec = 0;
+        snprintf(temp_buffer, sizeof(temp_buffer) - 1, "flapjackfeeder: configure %ss as timeout for redis connects/writes.", val);
+        temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
+        write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
     }
 
     else {

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -417,7 +417,7 @@ int npcdmod_process_module_args(char *args) {
     }
 
     /* terminate the arg list */
-    arglist[argcount] = '\x0';
+    arglist[argcount] = NULL;
 
     /* process each argument */
     for (arg = 0; arg < argcount; arg++) {

--- a/src/flapjackfeeder.c
+++ b/src/flapjackfeeder.c
@@ -121,6 +121,7 @@ int nebmodule_init(int flags, char *args, nebmodule *handle) {
     
         /* open redis connection to push check results */
         currentredistarget->rediscontext = redisConnectWithTimeout(currentredistarget->redis_host, atoi(currentredistarget->redis_port), timeout);
+        redisSetTimeout(currentredistarget->rediscontext, timeout);
         currentredistarget->redis_connection_established = 0;
         if (currentredistarget->rediscontext == NULL || currentredistarget->rediscontext->err) {
             if (currentredistarget->rediscontext) {
@@ -191,6 +192,7 @@ void npcdmod_file_roller() {
             temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
             write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
             currentredistarget->rediscontext = redisConnectWithTimeout(currentredistarget->redis_host, atoi(currentredistarget->redis_port), timeout);
+            redisSetTimeout(currentredistarget->rediscontext, timeout);
             if (currentredistarget->rediscontext == NULL || currentredistarget->rediscontext->err) {
                 if (currentredistarget->rediscontext) {
                     snprintf(temp_buffer, sizeof(temp_buffer) - 1,


### PR DESCRIPTION
I've implemented support for feeding multiple redis targets.

Via specifying more than one (host, port) tuple as options when loading the event broker module into nagios, we can feed more than one reds now.
```
broker_module=/usr/local/lib/flapjackfeeder.o redis_host=127.0.0.1,redis_port=6381,redis_host=localhost,redis_port=6380
```
This will work with as many targets as you want. 
It will feed any reachable target and try to (re)connect to unreachable targets every 15 seconds (configurable via `redis_connect_retry_interval=15`).
The reconnect attempt has a timeout of 1.5 seconds, which is the only nagios blocking part of the code except from the LPUSH to redis that could be slow as well, but if that fails to be fast (1.5s timeout), the connection will be considered unreachable and reconnected.
Therefore watch out for lines like this in the nagios.log:
```
[1432570967] flapjackfeeder: redis connection has to be (re)established (redis host '127.0.0.1', redis port '6381').
[1432570967] flapjackfeeder: Connection error: 'Connection refused'. But I'll retry to connect regulary.
```